### PR TITLE
Add basic auth when testing the TradeTariff app.

### DIFF
--- a/src/test/scala/tradetariff/ApiQuotasSimulation.scala
+++ b/src/test/scala/tradetariff/ApiQuotasSimulation.scala
@@ -14,6 +14,7 @@ class ApiQuotasSimulation extends Simulation {
   val request = exec(
     http("Get quota order numbers")
       .get("/quota_order_numbers")
+      .basicAuth(System.getenv("BASIC_AUTH_USERNAME"), System.getenv("BASIC_AUTH_PASSWORD"))
   ).pause(1)
 
   val sectionsScenario = scenario("API V2 Quotas").exec(request)

--- a/src/test/scala/tradetariff/BrowseSimulation.scala
+++ b/src/test/scala/tradetariff/BrowseSimulation.scala
@@ -19,6 +19,7 @@ class BrowseSimulation extends Simulation {
       .exec(
         http("Load Section ${section}")
           .get("/sections/${section}")
+          .basicAuth(System.getenv("BASIC_AUTH_USERNAME"), System.getenv("BASIC_AUTH_PASSWORD"))
       )
       .pause(1)
       .exec(

--- a/src/test/scala/tradetariff/CommoditiesSimulation.scala
+++ b/src/test/scala/tradetariff/CommoditiesSimulation.scala
@@ -19,6 +19,7 @@ class CommoditiesSimulation extends Simulation   {
       .exec(
         http("UK Commodity")
           .get("/commodities/${commodity}")
+          .basicAuth(System.getenv("BASIC_AUTH_USERNAME"), System.getenv("BASIC_AUTH_PASSWORD"))
       )
       .pause(1)
       .exec(

--- a/src/test/scala/tradetariff/SearchSimulation.scala
+++ b/src/test/scala/tradetariff/SearchSimulation.scala
@@ -18,6 +18,7 @@ class SearchSimulation extends Simulation {
     .exec(
       http("Search")
         .get("/search?q=${query}")
+        .basicAuth(System.getenv("BASIC_AUTH_USERNAME"), System.getenv("BASIC_AUTH_PASSWORD"))
     ).pause(1)
 
   val searchScenario = scenario("Search").exec(request)

--- a/src/test/scala/tradetariff/SectionsSimulation.scala
+++ b/src/test/scala/tradetariff/SectionsSimulation.scala
@@ -8,7 +8,6 @@ import io.gatling.http.request.builder.HttpRequestBuilder.toActionBuilder
 import scala.concurrent.duration._
 
 class SectionsSimulation extends Simulation {
-
   val httpProtocol: HttpProtocolBuilder = http
     .baseUrl("https://tariff-frontend-staging.london.cloudapps.digital")
 
@@ -17,6 +16,7 @@ class SectionsSimulation extends Simulation {
   val request = exec(
     http("Sections index")
       .get("/sections")
+      .basicAuth(System.getenv("BASIC_AUTH_USERNAME"), System.getenv("BASIC_AUTH_PASSWORD"))
   ).pause(1)
     .feed(sectionFeeder)
     .exec(


### PR DESCRIPTION
Note:
To use the ENV vars, set the `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`.

An easy way is the following:

`> BASIC_AUTH_USERNAME=tariff BASIC_AUTH_PASSWORD=XXXXXXXX sbt`
