### PR TITLE
add and update beta search simulation

### DIFF
--- a/src/test/resources/search_queries.csv
+++ b/src/test/resources/search_queries.csv
@@ -180,9 +180,9 @@ Cream
 Milk
 Yogurt
 Not exceeding 1,5 %
-Exceeding 27 %
-Not exceeding 3 %
-Not exceeding 3 %
+Exceeding 27%
+Not exceeding
+Not exceeding
 Exceeding 1,5 %
 Exceeding 6 %
 Exceeding 6 %
@@ -202,8 +202,8 @@ Skyr
 curd
 Processed Emmentaler
 Processed Gruyère
-Not exceeding 48 %
-Exceeding 48 %
+Not exceeding 48
+Exceeding 48
 Niva
 Roquefort
 Gorgonzola
@@ -904,13 +904,13 @@ Prepared mustard
 Containing tomato
 Mayonnaise
 For infant use
-7 % or more
+or more
 Cheese fondues
 Isoglucose syrups
 Lactose syrup
 Not carbonated
 Less than 0,2 %
-2 % or more
+or more
 Non-alcoholic beer
 In bottles
 Sparkling wine

--- a/src/test/scala/tradetariff/BetaSearchSimulation.scala
+++ b/src/test/scala/tradetariff/BetaSearchSimulation.scala
@@ -1,0 +1,36 @@
+package tradetariff
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+import io.gatling.http.protocol.HttpProtocolBuilder
+import io.gatling.http.request.builder.HttpRequestBuilder.toActionBuilder
+
+import scala.concurrent.duration._
+
+class BetaSearchSimulation extends Simulation {
+
+  val httpProtocol: HttpProtocolBuilder = http
+    .baseUrl("https://staging.trade-tariff.service.gov.uk")
+
+  val searchQueries = csv("search_queries.csv").random
+
+  val request = feed(searchQueries)
+    .exec(
+      http("BetaSearch ${query}")
+        .get("/uk/api/beta/search?q=${query}")
+        .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15")
+        .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+        .header("Accept-Encoding", "gzip, deflate, br")
+        .header("Connection", "keep-alive")
+        // .basicAuth(System.getenv("BASIC_AUTH_USERNAME"), System.getenv("BASIC_AUTH_PASSWORD"))
+    ).pause(1)
+
+  val searchScenario = scenario("BetaSearch").exec(request)
+
+  setUp(
+    searchScenario.inject(
+      rampConcurrentUsers(1).to(25).during(60.seconds),
+      constantConcurrentUsers(25).during(5.minutes)
+    ).protocols(httpProtocol)
+  )
+}

--- a/src/test/scala/tradetariff/SearchSimulation.scala
+++ b/src/test/scala/tradetariff/SearchSimulation.scala
@@ -30,3 +30,4 @@ class SearchSimulation extends Simulation {
     )
   ).protocols(httpProtocol)
 }
+


### PR DESCRIPTION
Jira link

- HOTT-<2149> [https://transformuk.atlassian.net/browse/HOTT-2149]

What?
I have added/removed/altered the following:

- added new simulation for beta search and updated with new scenario changes.

Why?
I am doing this because:

- To execute load tests for new beta search and ensure that the response times for new beta search are in the acceptable range.