### PR TITLE
HOTT-3060 Dependency updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:8-jdk
+FROM eclipse-temurin:17-jdk
 
 ENV PATH="$PATH:/root/.local/share/coursier/bin"
 RUN curl -fL https://github.com/coursier/coursier/releases/latest/download/cs-x86_64-pc-linux.gz | gzip -d > /usr/bin/cs && chmod +x /usr/bin/cs && cs setup --yes
@@ -8,7 +8,8 @@ ADD project /app/project
 ADD src /app/src
 WORKDIR /app
 
+VOLUME /app/target
 RUN sbt clean compile
 
 ENTRYPOINT ["sbt"]
-CMD ["gatling:test"]
+CMD ["Gatling / test"]

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 enablePlugins(GatlingPlugin)
 
-scalaVersion := "2.13.4"
+scalaVersion := "3.2.2"
 
 scalacOptions := Seq(
-  "-encoding", "UTF-8", "-target:jvm-1.8", "-deprecation",
+  "-encoding", "UTF-8", "-release", "8", "-deprecation",
   "-feature", "-unchecked", "-language:implicitConversions", "-language:postfixOps")
 
-val gatlingVersion = "3.5.0"
+val gatlingVersion = "3.9.5"
 libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion % "test"
 libraryDependencies += "io.gatling"            % "gatling-test-framework"    % gatlingVersion % "test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.8.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.gatling" % "gatling-sbt" % "3.2.1")
+addSbtPlugin("io.gatling" % "gatling-sbt" % "4.3.2")

--- a/src/test/scala/tradetariff/ApiQuotasSimulation.scala
+++ b/src/test/scala/tradetariff/ApiQuotasSimulation.scala
@@ -3,7 +3,6 @@ package tradetariff
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import io.gatling.http.protocol.HttpProtocolBuilder
-import io.gatling.http.request.builder.HttpRequestBuilder.toActionBuilder
 
 import scala.concurrent.duration._
 

--- a/src/test/scala/tradetariff/BrowseSimulation.scala
+++ b/src/test/scala/tradetariff/BrowseSimulation.scala
@@ -17,23 +17,23 @@ class BrowseSimulation extends Simulation {
 
   val request = feed(feeder)
       .exec(
-        http("Load Section ${section}")
-          .get("/sections/${section}")
+        http("Load Section #{section}")
+          .get("/sections/#{section}")
       )
       .pause(1)
       .exec(
-        http("Load Chapter ${chapter}")
-          .get("/chapters/${chapter}")
+        http("Load Chapter #{chapter}")
+          .get("/chapters/#{chapter}")
       )
       .pause(1)
       .exec(
-        http("Load Heading ${heading}")
-          .get("/headings/${heading}")
+        http("Load Heading #{heading}")
+          .get("/headings/#{heading}")
       )
       .pause(1)
       .exec(
-        http("Load Commodity ${commodity}")
-          .get("/commodities/${commodity}")
+        http("Load Commodity #{commodity}")
+          .get("/commodities/#{commodity}")
       )
 
     val scn = scenario("BrowseSimulation").exec(request)

--- a/src/test/scala/tradetariff/CommoditiesSimulation.scala
+++ b/src/test/scala/tradetariff/CommoditiesSimulation.scala
@@ -4,8 +4,6 @@ import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import scala.concurrent.duration._
 import io.gatling.http.protocol.HttpProtocolBuilder
-import io.gatling.http.request.builder.HttpRequestBuilder.toActionBuilder
-
 
 class CommoditiesSimulation extends Simulation   {
 
@@ -18,12 +16,12 @@ class CommoditiesSimulation extends Simulation   {
     feed(commoditiesFeeder)
       .exec(
         http("UK Commodity")
-          .get("/commodities/${commodity}")
+          .get("/commodities/#{commodity}")
       )
       .pause(1)
       .exec(
         http("XI Commodity")
-          .get("/xi/commodities/${commodity}")
+          .get("/xi/commodities/#{commodity}")
       )
 
   val commoditiesScenario = scenario("Commodities").exec(request)

--- a/src/test/scala/tradetariff/SearchSimulation.scala
+++ b/src/test/scala/tradetariff/SearchSimulation.scala
@@ -3,7 +3,6 @@ package tradetariff
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import io.gatling.http.protocol.HttpProtocolBuilder
-import io.gatling.http.request.builder.HttpRequestBuilder.toActionBuilder
 
 import scala.concurrent.duration._
 
@@ -17,7 +16,7 @@ class SearchSimulation extends Simulation {
   val request = feed(searchQueries)
     .exec(
       http("Search")
-        .get("/search?q=${query}")
+        .get("/search?q=#{query}")
     ).pause(1)
 
   val searchScenario = scenario("Search").exec(request)

--- a/src/test/scala/tradetariff/SectionsSimulation.scala
+++ b/src/test/scala/tradetariff/SectionsSimulation.scala
@@ -3,7 +3,6 @@ package tradetariff
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import io.gatling.http.protocol.HttpProtocolBuilder
-import io.gatling.http.request.builder.HttpRequestBuilder.toActionBuilder
 
 import scala.concurrent.duration._
 
@@ -19,13 +18,13 @@ class SectionsSimulation extends Simulation {
   ).pause(1)
     .feed(sectionFeeder)
     .exec(
-      http("Section ${section}")
-        .get("/sections/${section}")
+      http("Section #{section}")
+        .get("/sections/#{section}")
     )
     .pause(1)
     .exec(
       http("Random Chapter")
-        .get("/chapters/${chapters.random()}")
+        .get("/chapters/#{chapters.random()}")
     )
 
   val sectionsScenario = scenario("Sections").exec(request)


### PR DESCRIPTION
## Changes

* Upgraded Gatling to 3.9.5
* Upgraded Gatling-SBT plugin to 4.3.2
* Upgraded SBT to 1.8.3
* Upgraded Scala to 3.2.2
* JVM to 17
* Amended specs for compatiblity with current versions

## Why

We should use current dependencies where possible for security and because it is easier to stay current then try to 'catch up' long after