### PR TITLE
HOTT-4366 Fix building Dockerfile on m1 macs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk
+FROM --platform=linux/amd64 eclipse-temurin:17-jdk
 
 ENV PATH="$PATH:/root/.local/share/coursier/bin"
 


### PR DESCRIPTION
Coursier only publishes x64 releases, so force building the platform to x64

This isn't ideal since it means the performance suite is running under emulation _but_ it is primarily network stack level behaviour and only generating HEAD tags so should hopefully be fairly low impact and is definitely better than it not running.